### PR TITLE
将模块名称由硬编码修改为NODE_GYP_MODULE_NAME宏

### DIFF
--- a/packages/boa/src/binding.cc
+++ b/packages/boa/src/binding.cc
@@ -18,4 +18,4 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
   return exports;
 }
 
-NODE_API_MODULE(boa, Init)
+NODE_API_MODULE(NODE_GYP_MODULE_NAME, Init)


### PR DESCRIPTION
将模块名称由硬编码修改为NODE_GYP_MODULE_NAME宏，确保会将最终二进制文件的名称传给 NODE_MODULE()